### PR TITLE
Fix todo API validation and error responses

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,9 +5,24 @@ require 'json'
 set :port, 8080
 set :bind, '0.0.0.0'
 
+before do
+  content_type :json if request.path_info.start_with?('/api/')
+end
+
 # In-memory todo store
 $todos = []
 $next_id = 1
+
+helpers do
+  def parse_json_body
+    raw = request.body.read
+    halt 400, json(error: 'Request body is required') if raw.nil? || raw.strip.empty?
+
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Malformed JSON')
+  end
+end
 
 # Pages
 get '/' do
@@ -28,21 +43,30 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  data = parse_json_body
+  text = data['text']&.strip
+  halt 422, json(error: 'text is required') if text.nil? || text.empty?
+
+  todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
+
+  status 201
   json todo
 end
 
 patch '/api/todos/:id' do
   todo = $todos.find { |t| t[:id] == params[:id].to_i }
   halt 404, json(error: 'Not found') unless todo
+
   todo[:done] = !todo[:done]
   json todo
 end
 
 delete '/api/todos/:id' do
+  removed_todo = $todos.find { |t| t[:id] == params[:id].to_i }
+  halt 404, json(error: 'Not found') unless removed_todo
+
   $todos.reject! { |t| t[:id] == params[:id].to_i }
   json success: true
 end


### PR DESCRIPTION
### Motivation
- Prevent server errors and unclear responses when clients send empty or malformed JSON to the API.
- Ensure created todos are valid and that API endpoints follow expected HTTP semantics for create/delete errors.

### Description
- Add a `before` filter so `/api/*` routes consistently return `application/json` content type and make responses predictable.
- Introduce a `parse_json_body` helper that returns `400` with a clear JSON error when the request body is empty or contains malformed JSON.
- Validate `text` on `POST /api/todos` and return `422` when `text` is missing or blank, and return `201` on successful creation.
- Return `404` from `DELETE /api/todos/:id` when the requested todo does not exist instead of always returning success.

### Testing
- Ran `ruby -c app.rb` and received `Syntax OK`, indicating the updated file parses correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a35a5f7c8330a7a9d9aaa46ba12e)