### PR TITLE
Fix security vulnerabilities and input validation bugs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,10 +28,22 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  halt 400, json(error: 'Request body must be a JSON object') unless data.is_a?(Hash)
+
+  text = data['text']
+  halt 400, json(error: 'text is required') unless text.is_a?(String) && !text.strip.empty?
+  halt 400, json(error: 'text must be 500 characters or fewer') if text.length > 500
+
+  todo = { id: $next_id, text: text.strip, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
+  status 201
   json todo
 end
 
@@ -43,7 +55,9 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  halt 404, json(error: 'Not found') unless $todos.any? { |t| t[:id] == id }
+  $todos.reject! { |t| t[:id] == id }
   json success: true
 end
 
@@ -51,8 +65,6 @@ get '/api/stats' do
   json(
     total: $todos.size,
     done: $todos.count { |t| t[:done] },
-    pending: $todos.count { |t| !t[:done] },
-    server_time: Time.now.to_s,
-    ruby_version: RUBY_VERSION
+    pending: $todos.count { |t| !t[:done] }
   )
 end

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,15 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const info = document.getElementById('server-info');
+      info.innerHTML = '';
+      [['Todos Created', data.total], ['Todos Completed', data.done]].forEach(function(pair) {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = pair[0] + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + Number(pair[1])));
+        info.appendChild(p);
+      });
     });
 </script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -350,7 +350,7 @@
   </main>
 
   <footer>
-    Built with Ruby <%= RUBY_VERSION %> &middot; Sinatra &middot; <%= Time.now.year %>
+    Built with Ruby &amp; Sinatra &middot; <%= Time.now.year %>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary

This PR fixes real security and correctness bugs found during a code review of `app.rb`, `views/about.erb`, and `views/layout.erb`. No cosmetic changes are included.

### Issues fixed

**`app.rb` — `POST /api/todos` (unhandled errors + missing validation)**
- `JSON.parse(request.body.read)` had no rescue; a malformed body raised `JSON::ParserError` → unhandled 500. Now returns `400 Invalid JSON`.
- No check that the parsed value was a Hash; a bare JSON string/array/number would cause a `NoMethodError` on `data['text']`.
- `text` was never validated: a missing key, `null`, or blank string would silently create a broken todo. Now enforces: present, non-empty String, ≤ 500 characters.
- Response status was 200 for a created resource; corrected to `201 Created`.

**`app.rb` — `DELETE /api/todos/:id` (silent false success)**
- `reject!` is a no-op when the ID doesn't exist, but the endpoint returned `{success: true}` regardless. Now returns `404` when the ID is not found, consistent with the `PATCH` endpoint.

**`app.rb` + `views/layout.erb` — Information disclosure (`RUBY_VERSION`)**
- `/api/stats` was returning `ruby_version` and `server_time`. Exposing the exact Ruby version helps attackers target known CVEs for that version. Both fields removed.
- The page footer embedded `<%= RUBY_VERSION %>` in every rendered HTML page. Replaced with plain text.

**`views/about.erb` — Unsafe `innerHTML` with server string data**
- The server-info panel was built via a template-literal `innerHTML` assignment that included `data.ruby_version` and `data.server_time` — string fields that could carry arbitrary content if the API response were tampered with (e.g. MITM on HTTP). Replaced with safe DOM construction (`createElement` / `textContent`) and updated to show only the integer stats that remain after the API cleanup.

## Test plan

- [ ] `POST /api/todos` with no body → `400 Invalid JSON`
- [ ] `POST /api/todos` with `{}` → `400 text is required`
- [ ] `POST /api/todos` with `{"text": "  "}` → `400 text is required`
- [ ] `POST /api/todos` with `{"text": "buy milk"}` → `201` with todo object
- [ ] `DELETE /api/todos/9999` (non-existent) → `404`
- [ ] `GET /api/stats` → response contains `total`, `done`, `pending`; does **not** contain `ruby_version` or `server_time`
- [ ] Load `/` and `/about` in a browser — no Ruby version visible in footer or server-info panel

https://claude.ai/code/session_01R59qJyLLFMfKx8cUuZeS6t