### PR TITLE
Fix input validation, error handling, and DELETE semantics in API

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,8 +28,21 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text']
+  unless text.is_a?(String) && !text.strip.empty?
+    halt 422, json(error: 'text must be a non-empty string')
+  end
+  if text.length > 1000
+    halt 422, json(error: 'text must be 1000 characters or fewer')
+  end
+
+  todo = { id: $next_id, text: text.strip, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
   json todo
@@ -43,7 +56,9 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
+  before_count = $todos.size
   $todos.reject! { |t| t[:id] == params[:id].to_i }
+  halt 404, json(error: 'Not found') if $todos.size == before_count
   json success: true
 end
 


### PR DESCRIPTION
## Summary

Code review of `app.rb`, `views/*.erb` for security vulnerabilities, bugs, and correctness issues. Three real bugs were found and fixed; no XSS or SQL injection was present.

### Issues fixed

- **Unhandled `JSON::ParserError` on `POST /api/todos`** — malformed JSON bodies raised an unhandled exception, causing Sinatra to return a 500 with a stack trace. Wrapped `JSON.parse` in a `rescue` block and return 400 instead.

- **No input validation on `text` field** — missing, `nil`, empty, or arbitrarily large payloads were silently accepted and stored. Added validation: `text` must be a non-empty string of at most 1,000 characters; returns 422 with a descriptive error otherwise.

- **`DELETE /api/todos/:id` always returned `{ success: true }`** — `reject!` is silent when nothing matches, so deleting a non-existent ID incorrectly returned a 200 success. Fixed to return 404 when the before/after size is unchanged.

### Not changed

- No XSS found: `home.erb` uses `escapeHtml()` before injecting todo text into the DOM; `about.erb` only injects server-controlled integers and constants via `innerHTML`.
- No SQL injection: the app uses in-memory arrays, no database.
- CSRF, auth, HTTPS, and binding to `0.0.0.0` are noted but out of scope for a demo app without sessions or a database.

## Test plan

- [ ] `POST /api/todos` with malformed JSON body returns 400
- [ ] `POST /api/todos` with missing/empty `text` returns 422
- [ ] `POST /api/todos` with `text` longer than 1000 chars returns 422
- [ ] `DELETE /api/todos/:id` with a valid existing ID returns 200
- [ ] `DELETE /api/todos/:id` with a non-existent ID returns 404
- [ ] Normal todo create/toggle/delete flow works end-to-end in the browser

https://claude.ai/code/session_018mRWLWdb5QXvC6d9viijEs