### PR TITLE
Fix API input validation, thread safety, error handling, and XSS pattern

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ set :bind, '0.0.0.0'
 # In-memory todo store
 $todos = []
 $next_id = 1
+$todos_mutex = Mutex.new
 
 # Pages
 get '/' do
@@ -28,22 +29,47 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
-  $next_id += 1
-  $todos << todo
+  data = begin
+    JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text']
+  halt 400, json(error: 'text must be a string') unless text.is_a?(String)
+  text = text.strip
+  halt 400, json(error: 'text cannot be empty') if text.empty?
+  halt 400, json(error: 'text must be 500 characters or fewer') if text.length > 500
+
+  todo = nil
+  $todos_mutex.synchronize do
+    todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
+    $next_id += 1
+    $todos << todo
+  end
   json todo
 end
 
 patch '/api/todos/:id' do
-  todo = $todos.find { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  todo = nil
+  $todos_mutex.synchronize do
+    todo = $todos.find { |t| t[:id] == id }
+    todo[:done] = !todo[:done] if todo
+  end
   halt 404, json(error: 'Not found') unless todo
-  todo[:done] = !todo[:done]
   json todo
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  deleted = false
+  $todos_mutex.synchronize do
+    before = $todos.size
+    $todos.reject! { |t| t[:id] == id }
+    deleted = $todos.size < before
+  end
+  halt 404, json(error: 'Not found') unless deleted
   json success: true
 end
 

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,20 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const info = document.getElementById('server-info');
+      info.innerHTML = '';
+      [
+        ['Ruby', data.ruby_version],
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done]
+      ].forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + value));
+        info.appendChild(p);
+      });
     });
 </script>


### PR DESCRIPTION
## Summary

Code review found five bugs spanning security, correctness, and unsafe patterns. All are fixed in this PR.

---

### 1. Unhandled `JSON::ParserError` → 500 (`app.rb:33`)

`JSON.parse` raises on malformed input. Without a rescue the server returns an unhandled 500 and spams the error log. Fixed with a `rescue JSON::ParserError` block that returns 400.

### 2. No input validation on todo `text` (`app.rb:38-42`)

`data['text']` was used without checking type or length. A caller could send `{"text": null}`, `{"text": {}}`, or a multi-megabyte string and the server would happily store it. Added:
- type guard (`text.is_a?(String)`)
- empty-after-strip check
- 500-character maximum length

### 3. Thread-unsafe global state (`app.rb:11,45-49,56-58,67-70`)

`$todos` and `$next_id` were read and mutated across request handlers with no synchronization. Concurrent requests could produce duplicate IDs or corrupt the array. Added `$todos_mutex = Mutex.new` and wrapped every read-modify-write with `$todos_mutex.synchronize`.

### 4. `DELETE /api/todos/:id` always returns success (`app.rb:64-74`)

`Array#reject!` gives no signal if no element matched. The endpoint returned `{success: true}` even for non-existent IDs. Fixed by comparing array size before and after the delete, and halting with 404 if nothing was removed.

### 5. `innerHTML` with unsanitized API data in `about.erb` (`views/about.erb:48-64`)

`data.ruby_version` and `data.server_time` were interpolated directly into an `innerHTML` template string. These values are server-controlled today, but the pattern would become reflected XSS the moment any of those fields carried user-influenced content. Replaced with `createElement`/`textContent` DOM construction.

## Test plan

- [ ] `POST /api/todos` with malformed JSON body returns 400
- [ ] `POST /api/todos` with `{"text": null}` returns 400
- [ ] `POST /api/todos` with a string > 500 chars returns 400
- [ ] `POST /api/todos` with valid text creates a todo and returns 201-style JSON
- [ ] `DELETE /api/todos/9999` (non-existent) returns 404
- [ ] `PATCH /api/todos/9999` (non-existent) returns 404
- [ ] `/about` page Server Info section still renders correctly
- [ ] Concurrent requests do not produce duplicate todo IDs

https://claude.ai/code/session_01JxTW2M6772oWK4ccrG7c2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxTW2M6772oWK4ccrG7c2V)_