### PR TITLE
Fix security issues, input validation bugs, and API correctness

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,10 +28,20 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text']
+  halt 400, json(error: 'text is required') if text.nil? || text.strip.empty?
+  halt 400, json(error: 'text must be 500 characters or fewer') if text.length > 500
+
+  todo = { id: $next_id, text: text.strip, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
+  status 201
   json todo
 end
 
@@ -43,7 +53,10 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  original_size = $todos.size
+  $todos.reject! { |t| t[:id] == id }
+  halt 404, json(error: 'Not found') if $todos.size == original_size
   json success: true
 end
 
@@ -52,7 +65,6 @@ get '/api/stats' do
     total: $todos.size,
     done: $todos.count { |t| t[:done] },
     pending: $todos.count { |t| !t[:done] },
-    server_time: Time.now.to_s,
-    ruby_version: RUBY_VERSION
+    server_time: Time.now.to_s
   )
 end

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,22 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const container = document.getElementById('server-info');
+      container.innerHTML = '';
+
+      const rows = [
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done],
+      ];
+
+      rows.forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + value));
+        container.appendChild(p);
+      });
     });
 </script>

--- a/views/home.erb
+++ b/views/home.erb
@@ -16,10 +16,6 @@
     <div class="stat-value" id="stat-pending">0</div>
     <div class="stat-label">Pending</div>
   </div>
-  <div class="stat">
-    <div class="stat-value" id="stat-ruby">-</div>
-    <div class="stat-label">Ruby Version</div>
-  </div>
 </div>
 
 <div class="grid-2">
@@ -74,7 +70,6 @@
       document.getElementById('stat-total').textContent = data.total;
       document.getElementById('stat-done').textContent = data.done;
       document.getElementById('stat-pending').textContent = data.pending;
-      document.getElementById('stat-ruby').textContent = data.ruby_version;
     } catch(e) {}
   }
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -350,7 +350,7 @@
   </main>
 
   <footer>
-    Built with Ruby <%= RUBY_VERSION %> &middot; Sinatra &middot; <%= Time.now.year %>
+    Built with Ruby &amp; Sinatra &middot; <%= Time.now.year %>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary

Security and correctness review of the Sinatra todo app. Seven issues found and fixed across `app.rb`, `views/about.erb`, `views/home.erb`, and `views/layout.erb`.

---

## Issues Fixed

### 1. Unhandled `JSON::ParserError` → server crash (`app.rb:31`)
**Before:** `JSON.parse(request.body.read)` raised an unhandled exception on any malformed or empty body, returning a 500.  
**After:** Wrapped in `rescue JSON::ParserError` → returns `400 Invalid JSON`.

### 2. Missing input validation on `text` field (`app.rb:32`)
**Before:** No nil check — `nil.strip` raised `NoMethodError` (500). No blank check, no length limit (DoS via huge payload).  
**After:** Validates `text` is present, non-blank, and ≤ 500 characters; returns 400 with a clear message on failure.

### 3. Wrong HTTP status on todo creation (`app.rb:35`)
**Before:** `POST /api/todos` returned `200 OK`.  
**After:** Returns `201 Created` as the HTTP spec requires for resource creation.

### 4. `DELETE /api/todos/:id` silently succeeds for non-existent IDs (`app.rb:46`)
**Before:** Always returned `{ success: true }` regardless of whether any item was actually removed.  
**After:** Compares list size before/after and returns `404 Not found` if nothing was deleted.

### 5. Information disclosure — `ruby_version` in API response (`app.rb:56`)
**Before:** `/api/stats` included `ruby_version: RUBY_VERSION` in every response.  
**After:** Field removed. Exposing the exact runtime version in a public API lets attackers trivially look up known CVEs for that version.

### 6. Information disclosure — `RUBY_VERSION` in rendered HTML footer (`layout.erb:353`)
**Before:** `Built with Ruby <%= RUBY_VERSION %> · Sinatra · …` was rendered in every page's `<footer>`.  
**After:** Replaced with the generic string `Built with Ruby & Sinatra · …`.

### 7. XSS-prone `innerHTML` pattern in `about.erb` (`about.erb:49–54`)
**Before:** Server data was interpolated directly into an `innerHTML` template string:
```js
container.innerHTML = `<p><strong>Ruby:</strong> ${data.ruby_version}</p>…`;
```
While the current fields (`server_time`, integer counts) are not user-controlled, this pattern becomes a stored XSS vector the moment any user-supplied field is added to `/api/stats`.  
**After:** Replaced with explicit `document.createElement` + `textContent` assignments — safe regardless of what the API returns.

---

## Test Plan

- [ ] `POST /api/todos` with no body → `400 Invalid JSON`
- [ ] `POST /api/todos` with `{}` (missing text) → `400 text is required`
- [ ] `POST /api/todos` with `{"text":""}` → `400 text is required`
- [ ] `POST /api/todos` with a 501-char text → `400 text must be 500 characters or fewer`
- [ ] `POST /api/todos` with valid text → `201` with todo object
- [ ] `DELETE /api/todos/9999` → `404 Not found`
- [ ] `DELETE /api/todos/:id` for existing ID → `200 { success: true }`
- [ ] `/api/stats` response does not contain `ruby_version`
- [ ] Page footer does not display Ruby version string
- [ ] About page server-info section renders correctly without `ruby_version` row

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNyZuwV7dXeDZ6wwyxMBb2)_