### PR TITLE
Fix API input validation, error handling, and info disclosure

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,10 +28,23 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  unless data.is_a?(Hash) && data['text'].is_a?(String) && !data['text'].strip.empty?
+    halt 400, json(error: 'text must be a non-empty string')
+  end
+
+  text = data['text'].strip
+  halt 400, json(error: 'text exceeds 500 character limit') if text.length > 500
+
+  todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
+  status 201
   json todo
 end
 
@@ -52,7 +65,6 @@ get '/api/stats' do
     total: $todos.size,
     done: $todos.count { |t| t[:done] },
     pending: $todos.count { |t| !t[:done] },
-    server_time: Time.now.to_s,
-    ruby_version: RUBY_VERSION
+    server_time: Time.now.to_s
   )
 end

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,20 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
-    });
+      const container = document.getElementById('server-info');
+      container.textContent = '';
+      [
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done]
+      ].forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + value));
+        container.appendChild(p);
+      });
+    })
+    .catch(e => console.error('Failed to load server info:', e));
 </script>

--- a/views/home.erb
+++ b/views/home.erb
@@ -74,8 +74,8 @@
       document.getElementById('stat-total').textContent = data.total;
       document.getElementById('stat-done').textContent = data.done;
       document.getElementById('stat-pending').textContent = data.pending;
-      document.getElementById('stat-ruby').textContent = data.ruby_version;
-    } catch(e) {}
+      document.getElementById('stat-ruby').textContent = '-';
+    } catch(e) { console.error('Failed to load stats:', e); }
   }
 
   // Todos
@@ -85,7 +85,7 @@
       const todos = await res.json();
       renderTodos(todos);
       loadStats();
-    } catch(e) {}
+    } catch(e) { console.error('Failed to load todos:', e); }
   }
 
   function renderTodos(todos) {

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -350,7 +350,7 @@
   </main>
 
   <footer>
-    Built with Ruby <%= RUBY_VERSION %> &middot; Sinatra &middot; <%= Time.now.year %>
+    Built with Ruby &amp; Sinatra &middot; <%= Time.now.year %>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary

Code review findings and fixes across `app.rb` and the view templates.

### Issues fixed

**1. Unhandled `JSON::ParserError` → 500 (app.rb:31)**
A malformed POST body (e.g. `curl -d 'not-json'`) raised an unrescued exception and returned a 500. Wrapped in `rescue JSON::ParserError` to return a proper 400 with an error message.

**2. Missing input validation on `data['text']` (app.rb:32)**
The endpoint accepted any value for `text` including `null`, non-string types, empty strings, and strings of unlimited length. Added guards:
- `data` must be a Hash and `text` must be a non-empty String
- Strip leading/trailing whitespace before storing (prevents blank-looking entries)
- Enforce a 500-character maximum to prevent memory abuse
- Returns 400 with a descriptive error on any violation

**3. Correct HTTP status on create (app.rb)**
`POST /api/todos` was returning 200; changed to 201 Created.

**4. Runtime fingerprinting via `RUBY_VERSION` (app.rb, layout.erb)**
`RUBY_VERSION` was exposed in both the `/api/stats` JSON response and the page footer, making it trivial for an attacker to identify and target known CVEs for the exact Ruby version. Removed from both locations.

**5. `innerHTML` with API data in about.erb**
Server info was rendered via template-literal interpolation into `innerHTML`. While the specific values (`server_time`, `total`, `done`) are currently server-controlled and safe, the pattern is risky — any future addition of user-influenced data to the stats endpoint would immediately become an XSS. Replaced with explicit DOM node construction using `textContent`.

**6. Silent error swallowing in home.erb / about.erb**
`catch(e) {}` discarded all fetch errors without any trace, making failures invisible during development and operations. Changed to `console.error(...)` so errors appear in the browser console.

## Test plan

- [ ] `POST /api/todos` with malformed JSON returns 400 `{"error":"Invalid JSON"}`
- [ ] `POST /api/todos` with `{}` or `{"text":""}` returns 400 `{"error":"text must be a non-empty string"}`
- [ ] `POST /api/todos` with a 501-char text returns 400 `{"error":"text exceeds 500 character limit"}`
- [ ] Valid `POST /api/todos` returns 201 with the new todo
- [ ] `GET /api/stats` response does not include `ruby_version`
- [ ] Page footer no longer shows the Ruby version string
- [ ] about.erb Server Info section still renders correctly
- [ ] Browser console shows errors when the API is unreachable (not silent)

https://claude.ai/code/session_011NJhwegsvbE5kq4V1rr9TP

---
_Generated by [Claude Code](https://claude.ai/code/session_011NJhwegsvbE5kq4V1rr9TP)_