### PR TITLE
Fix API input validation and error handling

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,8 +28,15 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+  text = data['text'].to_s.strip
+  halt 400, json(error: 'Text is required') if text.empty?
+  halt 400, json(error: 'Text must be 500 characters or fewer') if text.length > 500
+  todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
   json todo
@@ -43,7 +50,10 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  size_before = $todos.size
+  $todos.reject! { |t| t[:id] == id }
+  halt 404, json(error: 'Not found') if $todos.size == size_before
   json success: true
 end
 


### PR DESCRIPTION
## Summary

Three bugs found in `app.rb` during security/code review:

- **Unhandled JSON parse error** — `POST /api/todos` called `JSON.parse` without a rescue block. Any request with a malformed body raised `JSON::ParserError` and returned a 500; now returns 400 with a clear message.
- **No input validation on todo text** — the `text` field was accepted even when nil, empty, or missing, silently creating invalid todos. Now validates presence (after stripping whitespace) and enforces a 500-character maximum to prevent memory exhaustion.
- **DELETE always returned success** — `DELETE /api/todos/:id` called `reject!` and returned `{ success: true }` regardless of whether a matching todo existed. Callers had no way to distinguish a real delete from a no-op. Now returns 404 when no todo is found.

## What was reviewed and found clean

- `views/home.erb`: todo text is correctly escaped via `escapeHtml()` before DOM insertion — no XSS.
- `views/about.erb`: `innerHTML` interpolation only uses server-controlled constants (`RUBY_VERSION`, `Time.now`) — no user-controlled data path.
- `views/contact.erb`: form submit handler is client-only (no server round-trip) — no injection surface.
- `PATCH /api/todos/:id`: already returns 404 on missing todo.

## Test plan

- [ ] `POST /api/todos` with malformed JSON body → 400 `Invalid JSON`
- [ ] `POST /api/todos` with missing or empty `text` field → 400 `Text is required`
- [ ] `POST /api/todos` with `text` > 500 chars → 400 `Text must be 500 characters or fewer`
- [ ] `POST /api/todos` with whitespace-only text → 400 (stripped to empty)
- [ ] `DELETE /api/todos/99999` (nonexistent ID) → 404 `Not found`
- [ ] Normal create/toggle/delete flow still works end-to-end

https://claude.ai/code/session_012HUepFewXGizxV6Dos3i95

---
_Generated by [Claude Code](https://claude.ai/code/session_012HUepFewXGizxV6Dos3i95)_