### PR TITLE
Fix JSON parse errors, input validation, thread safety, and XSS pattern

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ set :bind, '0.0.0.0'
 # In-memory todo store
 $todos = []
 $next_id = 1
+$todo_mutex = Mutex.new
 
 # Pages
 get '/' do
@@ -24,34 +25,57 @@ end
 
 # API endpoints
 get '/api/todos' do
-  json $todos
+  json $todo_mutex.synchronize { $todos.dup }
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
-  $next_id += 1
-  $todos << todo
+  data = begin
+    JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text']
+  unless text.is_a?(String) && !text.strip.empty?
+    halt 400, json(error: 'text is required and must be a non-empty string')
+  end
+  text = text.strip
+  if text.length > 500
+    halt 400, json(error: 'text must be 500 characters or fewer')
+  end
+
+  todo = $todo_mutex.synchronize do
+    t = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
+    $next_id += 1
+    $todos << t
+    t
+  end
   json todo
 end
 
 patch '/api/todos/:id' do
-  todo = $todos.find { |t| t[:id] == params[:id].to_i }
+  todo = $todo_mutex.synchronize do
+    t = $todos.find { |t| t[:id] == params[:id].to_i }
+    t[:done] = !t[:done] if t
+    t
+  end
   halt 404, json(error: 'Not found') unless todo
-  todo[:done] = !todo[:done]
   json todo
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  $todo_mutex.synchronize do
+    $todos.reject! { |t| t[:id] == params[:id].to_i }
+  end
   json success: true
 end
 
 get '/api/stats' do
+  snapshot = $todo_mutex.synchronize { $todos.dup }
   json(
-    total: $todos.size,
-    done: $todos.count { |t| t[:done] },
-    pending: $todos.count { |t| !t[:done] },
+    total: snapshot.size,
+    done: snapshot.count { |t| t[:done] },
+    pending: snapshot.count { |t| !t[:done] },
     server_time: Time.now.to_s,
     ruby_version: RUBY_VERSION
   )

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,20 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const container = document.getElementById('server-info');
+      container.innerHTML = '';
+      [
+        ['Ruby', data.ruby_version],
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done]
+      ].forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + value));
+        container.appendChild(p);
+      });
     });
 </script>


### PR DESCRIPTION
## Summary

Code review identified four categories of real bugs in `app.rb` and one dangerous pattern in `views/about.erb`.

### Issues fixed

**1. Unhandled `JSON::ParserError` → 500 (`app.rb:31`)**
`JSON.parse(request.body.read)` was called without a rescue block. Any malformed request body (empty body, plain text, truncated JSON) would raise an unhandled exception, returning a 500 with a Ruby stack trace to the client. Now returns a clean 400 `{ "error": "Invalid JSON" }`.

**2. Missing input validation on `text` field (`app.rb:32`)**
The `text` key from the parsed JSON was used without checking whether it existed, was a string, or was non-empty. A missing key yields `nil`, creating a todo with `text: null` that breaks the client renderer. Now validates: must be a non-empty string, stripped of surrounding whitespace, and at most 500 characters (DoS guard). Missing/invalid input returns 400.

**3. Race condition on `$next_id` and `$todos` (`app.rb:9–10, 33`)**
Sinatra serves requests on multiple threads. `$next_id += 1` (a non-atomic read-modify-write) and bare `$todos <<` / `$todos.reject!` were completely unprotected. Concurrent requests could assign duplicate IDs or corrupt the array. A `Mutex` (`$todo_mutex`) now guards all reads and writes across every endpoint.

**4. XSS-by-pattern in `views/about.erb` (`about.erb:49`)**
The server-info block used `.innerHTML` with template-interpolated API values (`data.ruby_version`, `data.server_time`). While these specific fields aren't user-controlled today, the pattern is unsafe: if any of those API fields ever reflected user input, XSS would be trivial. Replaced with DOM API calls (`createElement`, `textContent`, `createTextNode`) which are safe by construction.

## Test plan

- [ ] `POST /api/todos` with a valid body `{"text":"buy milk"}` returns 201 with the todo object
- [ ] `POST /api/todos` with an empty body or non-JSON returns 400 `{"error":"Invalid JSON"}`
- [ ] `POST /api/todos` with `{}` (missing text) returns 400 `{"error":"text is required..."}`
- [ ] `POST /api/todos` with `{"text":""}` returns 400
- [ ] `POST /api/todos` with a 501-character text returns 400
- [ ] `PATCH /api/todos/999` returns 404 `{"error":"Not found"}`
- [ ] `GET /about` renders Server Info without using innerHTML (inspect DevTools Elements panel)
- [ ] Concurrent requests do not produce duplicate IDs (run a quick parallel curl loop)

https://claude.ai/code/session_01DZ8yNkQRhhTHFCP7AzsbkY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ8yNkQRhhTHFCP7AzsbkY)_