### PR TITLE
Fix input validation, error handling, and unsafe DOM pattern

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,8 +28,17 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text'].to_s.strip
+  halt 400, json(error: 'text is required') if text.empty?
+  halt 400, json(error: 'text must be 500 characters or fewer') if text.length > 500
+
+  todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
   json todo
@@ -43,7 +52,10 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  before = $todos.size
+  $todos.reject! { |t| t[:id] == id }
+  halt 404, json(error: 'Not found') if $todos.size == before
   json success: true
 end
 

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,20 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const el = document.getElementById('server-info');
+      el.innerHTML = '';
+      [
+        ['Ruby', data.ruby_version],
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done]
+      ].forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const b = document.createElement('strong');
+        b.textContent = label + ':';
+        p.appendChild(b);
+        p.appendChild(document.createTextNode(' ' + value));
+        el.appendChild(p);
+      });
     });
 </script>


### PR DESCRIPTION
## Summary

Security and correctness fixes found during code review.

### `app.rb` — `POST /api/todos`

**Bug: unhandled `JSON::ParserError` → 500**
Sending a non-JSON body (e.g. plain text, an empty body) caused `JSON.parse` to raise an unhandled exception, returning a 500 Internal Server Error instead of a 400 Bad Request. Fixed with a `rescue JSON::ParserError` block.

**Bug: no input validation on `text`**
- `data['text']` could be absent (nil), an empty/whitespace-only string, or an arbitrarily long string — all silently accepted and stored.
- Fixed: strip whitespace, reject empty text with 400, cap at 500 characters with 400.

### `app.rb` — `DELETE /api/todos/:id`

**Bug: always returns `{ success: true }` regardless of whether the ID existed**
`PATCH /api/todos/:id` correctly returns 404 for unknown IDs. `DELETE` did not, creating an inconsistent API. Fixed by comparing list size before/after `reject!` and halting with 404 if nothing was removed.

### `views/about.erb` — unsafe `innerHTML` pattern

The server-info panel was built by injecting API values into an `innerHTML` template literal. The current data (`ruby_version`, `server_time`, integer counts) is entirely server-controlled so there is no live XSS vector, but the pattern is unsafe by construction — if the data source ever becomes user-tainted the template silently becomes an injection sink. Replaced with explicit DOM construction (`createElement` + `textContent`) which is safe regardless of value content.

## Test plan

- [ ] `POST /api/todos` with no body → 400 `Invalid JSON`
- [ ] `POST /api/todos` with `{}` (missing `text`) → 400 `text is required`
- [ ] `POST /api/todos` with `{"text":""}` → 400 `text is required`
- [ ] `POST /api/todos` with `{"text":"x".repeat(501)}` → 400 `text must be 500 characters or fewer`
- [ ] `POST /api/todos` with valid `{"text":"buy milk"}` → 201-style 200 with the new todo
- [ ] `DELETE /api/todos/9999` (non-existent) → 404 `Not found`
- [ ] `DELETE /api/todos/:id` for an existing todo → 200 `{ success: true }`
- [ ] `/about` page loads and server-info block renders correctly without JS errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBWM97N1x2wqML3HEHHzi6)_