### PR TITLE
Fix input validation, error handling, and innerHTML XSS pattern

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,8 +28,17 @@ get '/api/todos' do
 end
 
 post '/api/todos' do
-  data = JSON.parse(request.body.read)
-  todo = { id: $next_id, text: data['text'], done: false, created_at: Time.now.to_s }
+  begin
+    data = JSON.parse(request.body.read)
+  rescue JSON::ParserError
+    halt 400, json(error: 'Invalid JSON')
+  end
+
+  text = data['text'].to_s.strip
+  halt 400, json(error: 'Text is required') if text.empty?
+  halt 400, json(error: 'Text is too long (max 500 characters)') if text.length > 500
+
+  todo = { id: $next_id, text: text, done: false, created_at: Time.now.to_s }
   $next_id += 1
   $todos << todo
   json todo
@@ -43,7 +52,9 @@ patch '/api/todos/:id' do
 end
 
 delete '/api/todos/:id' do
-  $todos.reject! { |t| t[:id] == params[:id].to_i }
+  id = params[:id].to_i
+  halt 404, json(error: 'Not found') unless $todos.any? { |t| t[:id] == id }
+  $todos.reject! { |t| t[:id] == id }
   json success: true
 end
 

--- a/views/about.erb
+++ b/views/about.erb
@@ -46,11 +46,20 @@
   fetch('/api/stats')
     .then(r => r.json())
     .then(data => {
-      document.getElementById('server-info').innerHTML = `
-        <p><strong>Ruby:</strong> ${data.ruby_version}</p>
-        <p><strong>Server Time:</strong> ${data.server_time}</p>
-        <p><strong>Todos Created:</strong> ${data.total}</p>
-        <p><strong>Todos Completed:</strong> ${data.done}</p>
-      `;
+      const el = document.getElementById('server-info');
+      el.innerHTML = '';
+      [
+        ['Ruby', data.ruby_version],
+        ['Server Time', data.server_time],
+        ['Todos Created', data.total],
+        ['Todos Completed', data.done]
+      ].forEach(([label, value]) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label + ':';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(' ' + value));
+        el.appendChild(p);
+      });
     });
 </script>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Code review found four issues worth fixing across `app.rb` and `views/about.erb`:

- **Unhandled `JSON::ParserError`** (`app.rb:31`): A malformed request body to `POST /api/todos` caused an uncaught exception, returning a 500 with a full backtrace potentially visible to the client. Now returns a clean 400 Bad Request.

- **Missing input validation on todo text** (`app.rb:32`): `data['text']` was used without any nil check, whitespace trimming, or length limit. A missing key stored `nil` as the todo text; an unbounded payload could exhaust server memory. Now: missing/empty text → 400, text > 500 chars → 400, whitespace stripped before storing.

- **`DELETE /api/todos/:id` always returned 200** (`app.rb:46`): `reject!` silently no-ops on unknown IDs, so the endpoint always responded `{"success":true}` regardless of whether anything was deleted — inconsistent with `PATCH` which correctly returns 404. Fixed to check existence first.

- **`innerHTML` with API data in `about.erb`** (`views/about.erb:49`): Server info was injected via an `innerHTML` template string. The specific values (Ruby version, server time, integer counts) are server-controlled today and not a live XSS vector, but the pattern is unsafe by default. Replaced with `createElement`/`textContent` DOM calls.

## Test plan

- [ ] `POST /api/todos` with body `not-json` → 400 `{"error":"Invalid JSON"}`
- [ ] `POST /api/todos` with `{}` (missing text) → 400 `{"error":"Text is required"}`
- [ ] `POST /api/todos` with text longer than 500 chars → 400 `{"error":"Text is too long..."}`
- [ ] `POST /api/todos` with valid text → 201, todo stored with whitespace stripped
- [ ] `DELETE /api/todos/9999` (nonexistent) → 404 `{"error":"Not found"}`
- [ ] `DELETE /api/todos/:id` on a real ID → 200 `{"success":true}`, item removed
- [ ] `/about` page loads, Server Info section populates correctly without console errors

https://claude.ai/code/session_01MMsGitSgvvwqeL9XauxhiU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMsGitSgvvwqeL9XauxhiU)_